### PR TITLE
Fixed upstream.url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <upstream.version>1.10.13</upstream.version>
-        <upstream.url>https://github.com/jquery/sizzle/blob/${upstream.version}/dist</upstream.url>
+        <upstream.url>https://raw.github.com/jquery/sizzle/${upstream.version}/dist</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
     </properties>
     


### PR DESCRIPTION
The existing upstream.url element was pulling the HTML page on the jquery/sizzle GitHub as a script file.  By referencing the raw page itself, only the script now comes through.
