### PR TITLE
Moved to Sizzle.js version 2.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>2.1.1</upstream.version>
+        <upstream.version>2.3.4</upstream.version>
         <upstream.url>https://raw.github.com/jquery/sizzle/${upstream.version}/dist</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
     </properties>


### PR DESCRIPTION
The included version of Sizzle.js has fallen a few releases behind.  This change simply updates to the most recent at 2.3.4.